### PR TITLE
Fix glitch with underscores in usernames

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -10,7 +10,7 @@ Installation
 
 Just drop this folder into MediaWiki's "extensions/" folder, and add
 
-    require_once( "$IP/extensions/ScratchSig2/ScratchSig2.php" );
+    require_once( "$IP/extensions/mw-ScratchSig2/ScratchSig2.php" );
 
 to your "LocalSettings.php".
 

--- a/ScratchSig2.php
+++ b/ScratchSig2.php
@@ -106,6 +106,6 @@ $wgResourceModules['ext.scratchSig'] = array(
     'styles' => 'scratchsig.css',
 
     'localBasePath' => __DIR__,
-    'remoteExtPath' => 'ScratchSig2'
+    'remoteExtPath' => 'mw-ScratchSig2'
 );
 

--- a/ScratchSig2.php
+++ b/ScratchSig2.php
@@ -44,7 +44,7 @@ function sigParserInit (Parser $parser) {
 
 function sigFetchProfile ($username) {
     // Fetch page
-    $data = file_get_contents("http://scratch.mit.edu/site-api/users/all/$username/");
+    $data = file_get_contents('http://scratch.mit.edu/site-api/users/all/' . str_replace(' ', '_', $username) . '/');
     $json = json_decode($data, $assoc=true);
     $pk = $json['user']['pk'];
     $image_url = "http://cdn.scratch.mit.edu/get_image/user/{$pk}_18x18.png";
@@ -82,7 +82,7 @@ function sigRenderTag ($input, array $args, Parser $parser, PPFrame $frame) {
         . '</a>'
         . ' '
         . '('
-        . '<a href="/wiki/User_Talk:'.$username.'">talk</a>'
+        . '<a href="/wiki/User_talk:'.$username.'">talk</a>'
         . ' | '
         . '<a href="/wiki/Special:Contributions/'.$username.'">contribs</a>'
         . ')'


### PR DESCRIPTION
One of the problems is that if a user has an underscore in his/her username (since MediaWiki replaces them with spaces), the icon doesn't show at all. This fixes that problem by putting the underscores back. Also, beware that either the folder needs to be changed to mw-ScratchSig2 or the code (see the DIFF) below needs to be changed back.
